### PR TITLE
Fix Uncaught ReferenceError for fcWidget

### DIFF
--- a/js/freshdesk-messaging-facade.js
+++ b/js/freshdesk-messaging-facade.js
@@ -52,23 +52,25 @@ class FreshchatFacade extends HTMLElement {
       document.getElementById("freshdesk-messaging-icon").classList.add("freshdesk-messaging-icon-loading");
     };
 
-    // eslint-disable-next-line no-undef
-    fcWidget.init({
-      token: this.token,
-      host: this.host,
-      siteId: this.siteId,
-      config: {
-        headerProperty: {
-          hideChatButton: false,
+    if (typeof fcWidget !== "undefined") {
+      // eslint-disable-next-line no-undef
+      fcWidget.init({
+        token: this.token,
+        host: this.host,
+        siteId: this.siteId,
+        config: {
+          headerProperty: {
+            hideChatButton: false,
+          },
         },
-      },
-    });
+      });
 
-    // Hide the facade once the real one has loaded
-    // eslint-disable-next-line no-undef
-    fcWidget.on("widget:opened", function () {
-      document.getElementById("freshdesk-messaging-facade").setAttribute("hidden", "hidden");
-    });
+      // Hide the facade once the real one has loaded
+      // eslint-disable-next-line no-undef
+      fcWidget.on("widget:opened", function () {
+        document.getElementById("freshdesk-messaging-facade").setAttribute("hidden", "hidden");
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Related to #11

Fixes the Uncaught ReferenceError for `fcWidget` by ensuring it is defined before calling its methods.

- Adds a conditional check around `fcWidget.init` and `fcWidget.on` calls to verify `fcWidget` is defined, preventing the reference error from occurring.
- Ensures the error related to `fcWidget` not being defined no longer appears in the console, addressing the issue reported in the repository.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/coliff/freshdesk-messaging-facade/issues/11?shareId=1ee021fb-8c99-4ec7-be6a-31682ec6b45c).